### PR TITLE
prevent from panic when resp is nil

### DIFF
--- a/param/reader.go
+++ b/param/reader.go
@@ -44,10 +44,11 @@ func (this *ParamReader) Prepare() error {
 
 		uploadURL := this.config.BaseURL.ResolveReference(pathURL)
 		resp, err := this.config.HttpClient.Post(uploadURL.String(), "application/octet-stream", this.reader)
-		defer resp.Body.Close()
+
 		if err != nil {
 			return err
 		}
+		defer resp.Body.Close()		
 
 		buf := new(bytes.Buffer)
 		if _, err := buf.ReadFrom(resp.Body); err != nil {


### PR DESCRIPTION
when connection to  network is unstable, the resp could be nil, which leads to panic,
this PR fixed it
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0xa15d7c]

goroutine 127 [running]:
github.com/ConvertAPI/convertapi-go/param.(*ParamReader).Prepare(0xc000162400, 0x0, 0x0)
        /Users/admin/Documents/go_work/pkg/mod/github.com/!convert!a!p!i/convertapi-go@v0.0.0-20200828084953-a50e060af4f4/param/reader.go:47 +0x2fc
github.com/ConvertAPI/convertapi-go/param.(*ParamFile).Prepare(0xc000162400, 0xb57060, 0xc0005546f0)
        /Users/admin/Documents/go_work/pkg/mod/github.com/!convert!a!p!i/convertapi-go@v0.0.0-20200828084953-a50e060af4f4/param/file.go:35 +0x8b
github.com/ConvertAPI/convertapi-go/param.(*ParamFile).Values(0xc000162400, 0x4b0072, 0xc000370a00, 0x1, 0x0, 0xc00004ba88)
        /Users/admin/Documents/go_work/pkg/mod/github.com/!convert!a!p!i/convertapi-go@v0.0.0-20200828084953-a50e060af4f4/param/file.go:39 +0x2b
github.com/ConvertAPI/convertapi-go.prepareValues(0xc0004d9790, 0x1, 0x1, 0x1000, 0x5, 0x0)
        /Users/admin/Documents/go_work/pkg/mod/github.com/!convert!a!p!i/convertapi-go@v0.0.0-20200828084953-a50e060af4f4/convert.go:67 +0x94
github.com/ConvertAPI/convertapi-go.Convert.func1(0xc0000a6108, 0xc0004d9790, 0x1, 0x1, 0xc0000a6110, 0xb8af1c, 0x3, 0xb8bbb6, 0x4)
        /Users/admin/Documents/go_work/pkg/mod/github.com/!convert!a!p!i/convertapi-go@v0.0.0-20200828084953-a50e060af4f4/convert.go:25 +0x172
created by github.com/ConvertAPI/convertapi-go.Convert
        /Users/admin/Documents/go_work/pkg/mod/github.com/!convert!a!p!i/convertapi-go@v0.0.0-20200828084953-a50e060af4f4/convert.go:18 +0x165
```